### PR TITLE
fix(ci): Fix gradlew not found error in Android emulator runner

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -1,0 +1,197 @@
+name: Android CI
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Android Build & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        working-directory: android
+        run: chmod +x gradlew
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build Debug APK
+        working-directory: android
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Run Unit Tests
+        working-directory: android
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Generate Code Coverage Report
+        working-directory: android
+        run: ./gradlew jacocoTestReport
+
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-unit-test-results
+          path: android/app/build/reports/tests/testDebugUnitTest/
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          flags: android-unit
+          name: android-coverage
+          fail_ci_if_error: false
+          verbose: true
+
+  ui-tests:
+    name: Android UI Tests
+    # Using ubuntu-latest for reliable Android emulator with KVM hardware acceleration
+    # - Linux runners have better emulator stability than macOS
+    # - KVM provides near-native performance for x86_64 emulation
+    # - Recommended by android-emulator-runner maintainers
+    runs-on: ubuntu-latest
+    timeout-minutes: 45  # Increased from 30 to handle 88 UI tests + emulator boot
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        working-directory: android
+        run: chmod +x gradlew
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Cache AVD
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-28-x86_64-ubuntu-latest  # API 28 for stability (proven to work)
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28  # API 28 (Android 9) - proven stable in CI environments
+          target: google_apis
+          arch: x86_64  # x86_64 with KVM hardware acceleration
+          profile: Nexus 6
+          force-avd-creation: false
+          emulator-options: -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run instrumented tests on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28  # API 28 (Android 9) - proven stable in CI environments
+          target: google_apis
+          arch: x86_64  # x86_64 with KVM hardware acceleration
+          profile: Nexus 6
+          force-avd-creation: false
+          emulator-boot-timeout: 600  # 10 minutes timeout for boot
+          emulator-options: -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect
+          disable-animations: true
+          disable-spellchecker: true
+          disable-linux-hw-accel: false  # Enable KVM (false = don't disable)
+          script: |
+            set -e  # Exit on error
+
+            echo "=== Waiting for device to be ready ==="
+            adb wait-for-device
+            adb shell input keyevent 82
+
+            echo "=== Waiting for boot to complete ==="
+            adb shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
+            echo "Device fully booted"
+
+            echo "=== Building and installing test APKs ==="
+            cd android && ./gradlew assembleDebugAndroidTest --stacktrace
+
+            echo "=== Installing app and test APKs ==="
+            adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+            adb install -r android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+
+            echo "=== Granting runtime permissions ==="
+            adb shell pm grant com.justspent.app android.permission.RECORD_AUDIO
+            adb shell pm grant com.justspent.app android.permission.MODIFY_AUDIO_SETTINGS
+
+            # Verify permissions were granted
+            echo "=== Checking granted permissions ==="
+            adb shell dumpsys package com.justspent.app | grep permission || true
+
+            echo "=== Starting UI tests with timeout protection ==="
+            # Run tests with timeout to prevent hanging (35 minutes max for tests)
+            # This leaves 10 minutes for emulator boot and cleanup
+            cd android && timeout 35m ./gradlew connectedDebugAndroidTest --stacktrace --info || {
+              EXIT_CODE=$?
+              if [ $EXIT_CODE -eq 124 ]; then
+                echo "ERROR: Tests timed out after 35 minutes"
+                exit 1
+              else
+                echo "ERROR: Tests failed with exit code $EXIT_CODE"
+                exit $EXIT_CODE
+              fi
+            }
+
+            echo "=== UI tests completed successfully ==="
+
+      - name: Upload UI Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-ui-test-results
+          path: android/app/build/reports/androidTests/connected/
+
+      - name: Upload UI Test Screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-ui-test-screenshots
+          path: android/app/build/outputs/androidTest-results/

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -1,0 +1,140 @@
+name: iOS CI
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: iOS Build & Test
+    runs-on: macos-15  # macOS with Xcode 16+
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: |
+          # Use Xcode 16+ which supports iOS 17.0+
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer || \
+          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer || \
+          sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Boot Simulator and Grant Permissions
+        run: |
+          # Get simulator ID (any available iPhone 16, let Xcode choose iOS version)
+          SIMULATOR_ID=$(xcrun simctl list devices | grep "iPhone 16" | grep -v "unavailable" | head -n 1 | grep -oE '\([A-Z0-9-]+\)' | tr -d '()')
+
+          if [ -z "$SIMULATOR_ID" ]; then
+            echo "⚠️  Could not find iPhone 16 simulator"
+            exit 1
+          fi
+
+          echo "Found simulator: $SIMULATOR_ID"
+
+          # Boot simulator
+          echo "Booting simulator..."
+          xcrun simctl boot "$SIMULATOR_ID" || true
+
+          # Wait for simulator to fully boot
+          echo "Waiting for simulator to boot..."
+          sleep 10
+
+          # Grant permissions
+          echo "Granting microphone permission..."
+          xcrun simctl privacy "$SIMULATOR_ID" grant microphone com.justspent.app || true
+
+          echo "Granting speech recognition permission..."
+          xcrun simctl privacy "$SIMULATOR_ID" grant speech-recognition com.justspent.app || true
+
+          echo "✅ Permissions granted to iOS simulator"
+
+      - name: Cache Swift Package Manager dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/JustSpent/.build
+            ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Build iOS app
+        working-directory: ios/JustSpent
+        run: |
+          xcodebuild clean build \
+            -project JustSpent.xcodeproj \
+            -scheme JustSpent \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty || exit 1
+
+      - name: Run Unit Tests
+        working-directory: ios/JustSpent
+        run: |
+          xcodebuild test \
+            -project JustSpent.xcodeproj \
+            -scheme JustSpent \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -only-testing:JustSpentTests \
+            -enableCodeCoverage YES \
+            -resultBundlePath ./test-results-unit.xcresult \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty || exit 1
+
+      - name: Run UI Tests
+        working-directory: ios/JustSpent
+        run: |
+          xcodebuild test \
+            -project JustSpent.xcodeproj \
+            -scheme JustSpent \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -only-testing:JustSpentUITests \
+            -enableCodeCoverage YES \
+            -resultBundlePath ./test-results-ui.xcresult \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty || exit 1
+
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-unit-test-results
+          path: ios/JustSpent/test-results-unit.xcresult
+
+      - name: Upload UI Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ui-test-results
+          path: ios/JustSpent/test-results-ui.xcresult
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          flags: ios
+          name: ios-coverage
+          fail_ci_if_error: false
+          verbose: true
+          xcode: true
+          xcode_archive_path: ios/JustSpent/test-results-unit.xcresult
+
+      - name: Upload Test Logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-logs
+          path: |
+            ~/Library/Logs/DiagnosticReports/
+            ~/Library/Developer/Xcode/DerivedData/*/Logs/Test/

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,39 @@
+name: PR Checks
+
+# Hybrid CI/CD Approach:
+# - GitHub Actions: Runs automatically only on main branch (production safety net)
+# - Local CI: Used for feature branches during development (faster feedback)
+# - Manual Trigger: Available for any branch via GitHub Actions UI when needed
+
+on:
+  pull_request:  # Run on all PRs, regardless of target branch
+  push:
+    branches:
+      - main  # Only auto-run on pushes to main
+  workflow_dispatch:  # Allow manual triggering from GitHub UI for any branch
+
+# Cancel in-progress runs for the same workflow and PR/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Run both platform checks in parallel
+  android-checks:
+    name: Android Build & Test
+    uses: ./.github/workflows/ci-android.yml
+    secrets: inherit
+
+  ios-checks:
+    name: iOS Build & Test
+    uses: ./.github/workflows/ci-ios.yml
+    secrets: inherit
+
+  # Summary job that depends on both platform checks
+  all-checks-passed:
+    name: All Checks Passed
+    runs-on: ubuntu-latest
+    needs: [android-checks, ios-checks]
+    steps:
+      - name: All checks passed
+        run: echo "✅ All platform checks passed successfully!"


### PR DESCRIPTION
**Problem:**
The android-emulator-runner script was executing each line in a separate shell, causing `cd android` to not persist to subsequent `./gradlew` commands. This resulted in "./gradlew: not found" errors.

**Error from GitHub Actions:**
```
/usr/bin/sh -c cd android
/usr/bin/sh -c ./gradlew assembleDebugAndroidTest --stacktrace
/usr/bin/sh: 1: ./gradlew: not found
Error: The process '/usr/bin/sh' failed with exit code 127
```

**Root Cause:**
Each line in the script parameter runs in a separate shell process:
  /usr/bin/sh -c cd android          # Changes dir in one shell
  /usr/bin/sh -c ./gradlew ...       # Runs in NEW shell (root dir)

**Solution:**
1. Combined `cd android && ./gradlew` on same line (lines 155, 172)
2. Fixed APK paths to include `android/` prefix (lines 158-159)

**Changes:**
- Line 155: `cd android && ./gradlew assembleDebugAndroidTest --stacktrace`
- Line 172: `cd android && timeout 35m ./gradlew connectedDebugAndroidTest ...`
- Lines 158-159: Updated paths to `android/app/build/outputs/apk/...`

**Result:**
All gradle commands now execute in the correct android/ directory where gradlew is located.

Fixes: https://github.com/maneesh888/just-spent/pull/12