### PR TITLE
fix(ios-ci): Use OS=latest to auto-select available iOS SDK in GitHub…

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -69,7 +69,7 @@ jobs:
           xcodebuild clean build \
             -project JustSpent.xcodeproj \
             -scheme JustSpent \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -configuration Debug \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
@@ -82,7 +82,7 @@ jobs:
           xcodebuild test \
             -project JustSpent.xcodeproj \
             -scheme JustSpent \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -only-testing:JustSpentTests \
             -enableCodeCoverage YES \
             -resultBundlePath ./test-results-unit.xcresult \
@@ -97,7 +97,7 @@ jobs:
           xcodebuild test \
             -project JustSpent.xcodeproj \
             -scheme JustSpent \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -only-testing:JustSpentUITests \
             -enableCodeCoverage YES \
             -resultBundlePath ./test-results-ui.xcresult \


### PR DESCRIPTION
… Actions

Prevents SDK version mismatch between local development (iOS 26.0/Xcode 16.4) and GitHub Actions runners (iOS 18.2/Xcode 16.2).

This fix was previously applied but got overwritten during branch merges.