### PR TITLE
feat: Move locale-based currency to first position in onboarding list

### DIFF
--- a/android/app/src/androidTest/kotlin/com/justspent/app/OnboardingFlowUITest.kt
+++ b/android/app/src/androidTest/kotlin/com/justspent/app/OnboardingFlowUITest.kt
@@ -91,7 +91,7 @@ class OnboardingFlowUITest {
         Thread.sleep(800)
         composeTestRule.waitForIdle()
 
-        // AED is typically first - should be visible without scrolling
+        // Default currency is always first - should be visible without scrolling
         composeTestRule.onNodeWithTag("currency_option_AED")
             .assertExists()
             .assertHasClickAction()

--- a/android/app/src/main/java/com/justspent/app/ui/onboarding/CurrencyOnboardingScreen.kt
+++ b/android/app/src/main/java/com/justspent/app/ui/onboarding/CurrencyOnboardingScreen.kt
@@ -122,7 +122,7 @@ private fun CurrencySelectionList(
                 .testTag("currency_list"),
             contentPadding = PaddingValues(vertical = 4.dp)
         ) {
-            items(Currency.common) { currency ->
+            items(listOf(Currency.default) + Currency.common.filter { it != Currency.default }) { currency ->
                 CurrencyOnboardingRow(
                     currency = currency,
                     isSelected = currency == selectedCurrency,

--- a/ios/JustSpent/JustSpent/Views/CurrencyOnboardingView.swift
+++ b/ios/JustSpent/JustSpent/Views/CurrencyOnboardingView.swift
@@ -51,7 +51,7 @@ struct CurrencyOnboardingView: View {
 
                 // Currency Selection List (All 160+ currencies available)
                 List {
-                    ForEach(Currency.all.sorted(by: { $0.displayName < $1.displayName })) { currency in
+                    ForEach([Currency.default] + Currency.all.filter { $0 != Currency.default }.sorted(by: { $0.displayName < $1.displayName })) { currency in
                         CurrencyOnboardingRow(
                             currency: currency,
                             isSelected: currency == selectedCurrency


### PR DESCRIPTION
- Android: Reorder Currency.common to put default currency first
- iOS: Reorder Currency.all to put default currency first
- Update test comment to reflect new ordering behavior
- Improves UX by eliminating scrolling to find locale-based currency

Both platforms now display default currency at the top of the list, making it immediately visible without scrolling.