### PR TITLE
fix: Fix code coverage extraction in CI workflows

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -51,9 +51,12 @@ jobs:
           echo "Booting simulator..."
           xcrun simctl boot "$SIMULATOR_ID" || true
 
-          # Wait for simulator to fully boot
+          # Wait for simulator to fully boot (wait for bootstatus to complete)
           echo "Waiting for simulator to boot..."
-          sleep 10
+          xcrun simctl bootstatus "$SIMULATOR_ID" || true
+
+          # Additional short wait to ensure xcodebuild can recognize it
+          sleep 5
 
           # Grant permissions
           echo "Granting microphone permission..."


### PR DESCRIPTION
## Summary

Fixes the code coverage extraction in CI workflows that was showing 0.0% for both iOS and Android despite tests passing.

### Changes

**iOS:**
- Remove `xcpretty` from test steps as it interferes with code coverage data generation
- Use `tee` to capture test output while preserving xcodebuild exit code
- Add verification step to confirm xcresult contains coverage data

**Android:**
- Combine `testDebugUnitTest` and `jacocoUnitTestReport` in a single step
- Ensures JaCoCo report is generated immediately after tests complete
- Add debug output to list generated JaCoCo files

## Root Cause

**iOS:** The `xcpretty` tool was intercepting xcodebuild output which prevented the coverage data from being properly recorded in the xcresult bundle.

**Android:** The JaCoCo report generation task was in a separate workflow step and got SKIPPED because the test execution data wasn't available across steps.

## Test plan

- [ ] Push to feature branch and verify workflow runs
- [ ] Check that iOS coverage percentage is non-zero
- [ ] Check that Android coverage percentage is non-zero
- [ ] Verify PR comment shows actual coverage values

🤖 Generated with [Claude Code](https://claude.com/claude-code)